### PR TITLE
chore: copy literal expression of gh actions uses: docker://

### DIFF
--- a/.github/workflows/reusable-policy-conformance.yml
+++ b/.github/workflows/reusable-policy-conformance.yml
@@ -22,62 +22,62 @@ jobs:
           REF: ${{ steps.ref.outputs.ref }}
         run: |
           docker run \
-            -e "ACTIONS_CACHE_URL" \
-            -e "ACTIONS_RUNTIME_TOKEN" \
-            -e "ACTIONS_RUNTIME_URL" \
-            -e "GITHUB_ACTION" \
-            -e "GITHUB_ACTION_REF" \
-            -e "GITHUB_ACTION_REPOSITORY" \
-            -e "GITHUB_ACTOR" \
-            -e "GITHUB_ACTOR_ID" \
-            -e "GITHUB_API_URL" \
-            -e "GITHUB_BASE_REF" \
-            -e "GITHUB_ENV" \
-            -e "GITHUB_EVENT_NAME" \
-            -e "GITHUB_EVENT_PATH" \
-            -e "GITHUB_GRAPHQL_URL" \
-            -e "GITHUB_HEAD_REF" \
+            --workdir /github/workspace \
+            --rm \
+            -e "INPUT_TOKEN" \
+            -e "INPUT_ARGS" \
+            -e "HOME" \
             -e "GITHUB_JOB" \
-            -e "GITHUB_OUTPUT" \
-            -e "GITHUB_PATH" \
             -e "GITHUB_REF" \
+            -e "GITHUB_SHA" \
+            -e "GITHUB_REPOSITORY" \
+            -e "GITHUB_REPOSITORY_OWNER" \
+            -e "GITHUB_REPOSITORY_OWNER_ID" \
+            -e "GITHUB_RUN_ID" \
+            -e "GITHUB_RUN_NUMBER" \
+            -e "GITHUB_RETENTION_DAYS" \
+            -e "GITHUB_RUN_ATTEMPT" \
+            -e "GITHUB_REPOSITORY_ID" \
+            -e "GITHUB_ACTOR_ID" \
+            -e "GITHUB_ACTOR" \
+            -e "GITHUB_TRIGGERING_ACTOR" \
+            -e "GITHUB_WORKFLOW" \
+            -e "GITHUB_HEAD_REF" \
+            -e "GITHUB_BASE_REF" \
+            -e "GITHUB_EVENT_NAME" \
+            -e "GITHUB_SERVER_URL" \
+            -e "GITHUB_API_URL" \
+            -e "GITHUB_GRAPHQL_URL" \
             -e "GITHUB_REF_NAME" \
             -e "GITHUB_REF_PROTECTED" \
             -e "GITHUB_REF_TYPE" \
-            -e "GITHUB_REPOSITORY" \
-            -e "GITHUB_REPOSITORY_ID" \
-            -e "GITHUB_REPOSITORY_OWNER" \
-            -e "GITHUB_REPOSITORY_OWNER_ID" \
-            -e "GITHUB_RETENTION_DAYS" \
-            -e "GITHUB_RUN_ATTEMPT" \
-            -e "GITHUB_RUN_ID" \
-            -e "GITHUB_RUN_NUMBER" \
-            -e "GITHUB_SERVER_URL" \
-            -e "GITHUB_SHA" \
-            -e "GITHUB_STATE" \
-            -e "GITHUB_STEP_SUMMARY" \
-            -e "GITHUB_TRIGGERING_ACTOR" \
-            -e "GITHUB_WORKFLOW" \
             -e "GITHUB_WORKFLOW_REF" \
             -e "GITHUB_WORKFLOW_SHA" \
             -e "GITHUB_WORKSPACE" \
-            -e "HOME" \
-            -e "INPUT_ARGS" \
-            -e "RUNNER_ARCH" \
-            -e "RUNNER_ENVIRONMENT" \
-            -e "RUNNER_NAME" \
+            -e "GITHUB_ACTION" \
+            -e "GITHUB_EVENT_PATH" \
+            -e "GITHUB_ACTION_REPOSITORY" \
+            -e "GITHUB_ACTION_REF" \
+            -e "GITHUB_PATH" \
+            -e "GITHUB_ENV" \
+            -e "GITHUB_STEP_SUMMARY" \
+            -e "GITHUB_STATE" \
+            -e "GITHUB_OUTPUT" \
             -e "RUNNER_OS" \
-            -e "RUNNER_TEMP" \
+            -e "RUNNER_ARCH" \
+            -e "RUNNER_NAME" \
+            -e "RUNNER_ENVIRONMENT" \
             -e "RUNNER_TOOL_CACHE" \
+            -e "RUNNER_TEMP" \
             -e "RUNNER_WORKSPACE" \
-            -e CI=true \
+            -e "ACTIONS_RUNTIME_URL" \
+            -e "ACTIONS_RUNTIME_TOKEN" \
+            -e "ACTIONS_CACHE_URL" \
             -e GITHUB_ACTIONS=true \
-            -e GITHUB_EVENT_PATH=/github/workflow/event.json \
-            -e INPUT_TOKEN="$INPUT_TOKEN" \
-            -v "$PWD":"/github/workspace" \
+            -e CI=true \
+            -v "/var/run/docker.sock":"/var/run/docker.sock" \
             -v "/home/runner/work/_temp/_github_home":"/github/home" \
             -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" \
             -v "/home/runner/work/_temp/_runner_file_commands":"/github/file_commands" \
-            --workdir /github/workspace \
-            ghcr.io/geonet/base-images/siderolabs-conform:v0.1.0-alpha.27 \
-            enforce --commit-ref="$REF" --reporter=github
+            -v "$PWD":"/github/workspace" \
+            ghcr.io/siderolabs/conform:v0.1.0-alpha.27 enforce --commit-ref="$REF" --reporter=github


### PR DESCRIPTION
where is GitHub's magic in running Actions that are containers