### PR TITLE
chore: use tidier command for package discovery

### DIFF
--- a/.github/workflows/reusable-go-build-smoke-test.yml
+++ b/.github/workflows/reusable-go-build-smoke-test.yml
@@ -13,20 +13,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+          check-latest: true
       - id: run-info
         name: collect job run info
         run: |
           if [ -n "${{ inputs.paths }}" ]; then
             echo "paths=$(echo '${{ inputs.paths }}' | tr '\n' ' ')" >> $GITHUB_OUTPUT
           else
-            PATHS="$(grep -r 'package main' | sort | cut -d ':' -f1 | grep '.go$' | xargs -n 1 dirname | sort | uniq | grep -v vendor | xargs -i echo './{}' | xargs)"
+            PATHS="$(go list -json ./... | jq -r -s '.[] | select (.Name == "main") | .ImportPath' | xargs)"
             echo "paths="$PATHS"" >> $GITHUB_OUTPUT
           fi
-      - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
-        with:
-          go-version-file: go.mod
-          cache-dependency-path: go.sum
-          check-latest: true
       - id: build
         env:
           PATHS: ${{ steps.run-info.outputs.paths }}

--- a/.github/workflows/reusable-ko-build.yml
+++ b/.github/workflows/reusable-ko-build.yml
@@ -69,7 +69,7 @@ jobs:
           if [ -n "${{ inputs.paths }}" ]; then
             echo "paths=$(echo '${{ inputs.paths }}' | tr '\n' ' ')" >> $GITHUB_OUTPUT
           else
-            PATHS="$(grep -r 'package main' | sort | cut -d ':' -f1 | grep '.go$' | xargs -n 1 dirname | sort | uniq | grep -v vendor | xargs -i echo './{}' | xargs)"
+            PATHS="$(go list -json ./... | jq -r -s '.[] | select (.Name == "main") | .ImportPath' | xargs)"
             echo "paths="$PATHS"" >> $GITHUB_OUTPUT
           fi
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1


### PR DESCRIPTION
go appears to have a way of outputing the packages as json which can be parsed for their package names which is also acceptable for Go and Ko to consume