### PR TITLE
chore: remove local path ref from smoke test

### DIFF
--- a/.github/workflows/reusable-go-build-smoke-test.yml
+++ b/.github/workflows/reusable-go-build-smoke-test.yml
@@ -31,4 +31,4 @@ jobs:
         env:
           PATHS: ${{ steps.run-info.outputs.paths }}
         run: |
-          echo "$PATHS" | tr ' ' '\n' | xargs -i -n 1 go build -o /dev/null './{}'
+          echo "$PATHS" | tr ' ' '\n' | xargs -i -n 1 go build -o /dev/null '{}'


### PR DESCRIPTION
use plain package name